### PR TITLE
Fixed error in optimizeParams: compute metrics ii index

### DIFF
--- a/code_forOptimization/optimizeParams.m
+++ b/code_forOptimization/optimizeParams.m
@@ -131,7 +131,7 @@ folders = dir(fullfile(resDir, 'center*'));
 
 fprintf('Evaluating performance of each folder.\n')
 
-for ii = length(metrics); %1:length(metrics) 
+for ii = 1:length(metrics) 
     
     metric = metrics{ii};
     params.(metric).S= nan(ncents,nsigmas);


### PR DESCRIPTION
Index "ii" is only selecting the last metric (EMD), as being "ii = length(metrics)". Then it gives an error when accessing the metrics on the second for (which the "ii" index is using the "ii = 1:length(metrics)" instead).
