### PR TITLE
fix: Undefined variable fixed

### DIFF
--- a/code_forMetrics/similarity.m
+++ b/code_forMetrics/similarity.m
@@ -44,6 +44,6 @@ if toPlot
     subplot(131); imshow(map1, []);
     subplot(132); imshow(map2, []);
     subplot(133); imshow(diff, []);
-    title(['Similar parts = ', num2str(s)]);
+    title(['Similar parts = ', num2str(score)]);
     pause;
 end


### PR DESCRIPTION
When you try to run a similarity.m, it would return "Undefined Variable s on line 47".
The "s" is nowhere to be seen in this code, and I believe it was actually meant for "score" defined in line 40.